### PR TITLE
Create Service Solahart Jakarta Barat Telp:082111266245

### DIFF
--- a/Call Center service Solahart Call:082111266245
+++ b/Call Center service Solahart Call:082111266245
@@ -1,0 +1,24 @@
+Call Center Service Solahart Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Air Panas Telp:082111266245
+++ b/Service Air Panas Telp:082111266245
@@ -1,0 +1,24 @@
+Service Air Panas Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Pemanas Air Telp:082111266245
+++ b/Service Pemanas Air Telp:082111266245
@@ -1,0 +1,24 @@
+Service Pemanas Air Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Ancol Telp:082111266245
+++ b/Service Solahart Ancol Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Ancol Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Bekasi Telp:082111266245
+++ b/Service Solahart Bekasi Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Bekasi 21-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Bintaro Telp:082111266245
+++ b/Service Solahart Bintaro Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Bintaro Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Bogor Telp:082111266245
+++ b/Service Solahart Bogor Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Bogor Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Cempaka Putih Telp:082111266245
+++ b/Service Solahart Cempaka Putih Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Cempaka Putih Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Cilandak Telp:082111266245
+++ b/Service Solahart Cilandak Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Cilandak Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Cipete Telp:082111266245
+++ b/Service Solahart Cipete Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Cipete Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Ciputat Telp:082111266245
+++ b/Service Solahart Ciputat Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Ciputat Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Depok Telp:082111266245
+++ b/Service Solahart Depok Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah depok Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Grogol Telp:082111266245
+++ b/Service Solahart Grogol Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Grogol Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Barat Telp:081802966444
+++ b/Service Solahart Jakarta Barat Telp:081802966444
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Barat Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Barat Telp:082111266245
+++ b/Service Solahart Jakarta Barat Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Barat Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Pusat Telp:082111266245
+++ b/Service Solahart Jakarta Pusat Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Pusat Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Selatan Telp:081802966444
+++ b/Service Solahart Jakarta Selatan Telp:081802966444
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Selatan Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Selatan Telp:082111266245
+++ b/Service Solahart Jakarta Selatan Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Selatan Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Timur Telp:082111266245
+++ b/Service Solahart Jakarta Timur Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Timur Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Jakarta Utara Telp:082111266245
+++ b/Service Solahart Jakarta Utara Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Jakarta Utara Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Kebon Jeruk Telp:082111266245
+++ b/Service Solahart Kebon Jeruk Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah kebon Jeruk Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Kelapa Gading Telp:082111266245
+++ b/Service Solahart Kelapa Gading Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Kelapa Gading Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Kemang Jakarta Selatan Telp:082111266245
+++ b/Service Solahart Kemang Jakarta Selatan Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Kemang Jakarta Selatan Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Lippo Karawaci Telp:082111266245
+++ b/Service Solahart Lippo Karawaci Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Lippo Karawaci Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.co

--- a/Service Solahart Mangga Dua Telp:082111266245
+++ b/Service Solahart Mangga Dua Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Mangga Dua Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Pantai Indah Kapuk Telp:082111266245
+++ b/Service Solahart Pantai Indah Kapuk Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Pantai Indah Kapuk Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Pasar minggu Telp:082111266245
+++ b/Service Solahart Pasar minggu Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Pasar Minggu Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Senen Telp:082111266245
+++ b/Service Solahart Senen Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Senen Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Serpong Telp:082111266245
+++ b/Service Solahart Serpong Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Serpong Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com

--- a/Service Solahart Sunter Telp:082111266245
+++ b/Service Solahart Sunter Telp:082111266245
@@ -1,0 +1,24 @@
+Service Solahart Daerah Sunter Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
+1. service solahart air panas, Rp:250.000. 
+2. service wika, swh, Air Panas Rp:250.000. 
+3. service edward, servis ariston tenaga matahari Rp:250.000. 
+4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
+5. JUAL spare part solar water heater merk solahart, handal, wika swh 
+6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
+Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
+. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
+dibawah ini :
+1. Jakarta Barat, Puri Indah Kebon Jeruk
+2.< Jakarta Timur, Pondok Gede, Cibubur
+3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
+4.< Jakarta Utara, Pluit, Kapuk Muara
+5. Jakarta Pusat, Menteng, Kemayoran
+6. Bekasi
+7. Tangerang, Bsd Lippo Karawaci
+Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
+CV SOLAR TEKNIK 
+jl:haji dogol no.97 duren sawit jakarta timur 
+hp.. 0818 029 66 444.HP:082 111 266 245 
+telp; 021 36069559, 
+Email:solarteknik@yahoo.com
+Website: www.servicesolahart.webs.com


### PR DESCRIPTION
Service Solahart Daerah Jakarta Selatan Telp:021-36069559,cv solar teknik melayani jasa service solahart,Service Wika swh,Service Air Panas tenaga matahari, dan penjualan Solahart air Panas tenaga matahari (solar water.heater) berikut JASA kami tawarkan: 
1. service solahart air panas, Rp:250.000. 
2. service wika, swh, Air Panas Rp:250.000. 
3. service edward, servis ariston tenaga matahari Rp:250.000. 
4, Bongkar Pasang Atau Pindahan Mesin Pemanas Air 
5. JUAL spare part solar water heater merk solahart, handal, wika swh 
6. JUAL unit solar water heater merk solahart, handal, wika swh,Rp:14,500,000 
Dengan pelayanan yang BERPENGALAMAN, MURAH,team kami telah terlatih Dengan standar spesifikasi sesuai pabrikannya
. Seiring bertambahnya permintaan pelayanan konsumen dari berbagai daerah, saat ini kami telah membuka cabang dan pelayanan jasa kami meliputi untuk wilayah-wilayah
dibawah ini :
1. Jakarta Barat, Puri Indah Kebon Jeruk
2.< Jakarta Timur, Pondok Gede, Cibubur
3.< Jakarta Selatan, Ciputat, Bintaro, Pondok Indah
4.< Jakarta Utara, Pluit, Kapuk Muara
5. Jakarta Pusat, Menteng, Kemayoran
6. Bekasi
7. Tangerang, Bsd Lippo Karawaci
Untuk Layanan Jasa dan keterangan lebih lanjut silahkan hubunggi kami :CALL CENTER SERVICE SOLAHART 
CV SOLAR TEKNIK 
jl:haji dogol no.97 duren sawit jakarta timur 
hp.. 0818 029 66 444.HP:082 111 266 245 
telp; 021 36069559, 
Email:solarteknik@yahoo.com
Website: www.servicesolahart.webs.com